### PR TITLE
Update gitignore by including the documentation folder generated for Mondrian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ doc/examples_classification/
 doc/examples_regression/
 doc/examples_calibration/
 doc/examples_multilabel_classification/
+doc/examples_mondrian/
 doc/auto_examples/
 doc/modules/generated/
 doc/datasets/generated/

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,6 +8,7 @@ Development Lead
 * Thibault Cordier <thibault.a.cordier@capgemini.com>
 * Vincent Blot <vincent.blot@capgemini.com>
 * Louis Lacombe <louis.lacombe@capgemini.com>
+* Valentin Laurent <valentin.laurent@capgemini.com>
 
 Emeritus Core Developers
 ------------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,7 +4,7 @@ History
 
 0.9.x (2024-xx-xx)
 ------------------
-
+* Update gitignore by including the documentation folder generated for Mondrian
 
 
 0.9.0 (2024-09-03)


### PR DESCRIPTION
# Description

See title. Very small PR, not sure about how to update the history.rst, feedback welcome.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

/

# Checklist

- [x] I have read the [contributing guidelines](https://github.com/scikit-learn-contrib/MAPIE/blob/master/CONTRIBUTING.rst)
- [x] I have updated the [HISTORY.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/scikit-learn-contrib/MAPIE/blob/master/AUTHORS.rst) files
- [x] Linting passes successfully : `make lint`
- [x] Typing passes successfully : `make type-check`
- [x] Unit tests pass successfully : `make tests`
- [x] Coverage is 100% : `make coverage`
- [x] Documentation builds successfully : `make doc`